### PR TITLE
Addition of typeahed field

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "moment-timezone": "^0.5.31",
     "numeral": "^2.0.6",
     "react": "^16.13.1",
+    "react-bootstrap-typeahead": "^5.0.0-alpha.1",
     "react-dom": "^16.13.1",
     "react-input-range": "^1.3.0",
     "react-number-format": "^4.4.1",

--- a/src/components/Field.js
+++ b/src/components/Field.js
@@ -5,13 +5,13 @@ import PropTypes from "prop-types";
 import InputField from "./fields/InputField";
 import ChoiceField from "./fields/ChoiceField";
 import NumberField from "./fields/NumberField";
-import DatePicker from './fields/DatePicker';
-// import TypeAheadField from './TypeAhead';
+import DatePicker from "./fields/DatePicker";
+import TypeAheadField from "./TypeAhead";
 // import FileUploader from './FileUploader';
-import TextAreaField from './fields/TextAreaField';
+import TextAreaField from "./fields/TextAreaField";
 import InputRangeField from "./fields/InputRange";
-import ChecklistField from './fields/ChecklistField';
-import LabelField from './fields/LabelField';
+import ChecklistField from "./fields/ChecklistField";
+import LabelField from "./fields/LabelField";
 
 const Field = (props) => {
   const { type, editable, isLabel } = props;
@@ -26,14 +26,16 @@ const Field = (props) => {
       return <ChoiceField {...props} setIsEditing={setIsEditing} />;
     case "number":
       return <NumberField {...props} setIsEditing={setIsEditing} />;
-    case 'date':
+    case "date":
       return <DatePicker {...props} setIsEditing={setIsEditing} />;
-    case 'textarea':
+    case "textarea":
       return <TextAreaField {...props} setIsEditing={setIsEditing} />;
     case "input-range":
       return <InputRangeField {...props} setIsEditing={setIsEditing} />;
-    case 'checklist':
+    case "checklist":
       return <ChecklistField {...props} setIsEditing={setIsEditing} />;
+    case "typeahead":
+      return <TypeAheadField {...props} setIsEditing={setIsEditing} />;
     default:
       return null;
   }

--- a/src/components/fields/TypeAhead.js
+++ b/src/components/fields/TypeAhead.js
@@ -1,0 +1,231 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import styled from "styled-components";
+
+import { AsyncTypeahead, Typeahead } from "react-bootstrap-typeahead";
+
+import { ErrorLabel, FormField } from "../theme/css/Global";
+import "react-bootstrap-typeahead/css/Typeahead.css";
+
+const TypeAheadField = (props) => {
+  const [formValue, setFormValue] = useState("");
+  const {
+    label,
+    value,
+    error,
+    id,
+    typeAheadData,
+    options,
+    placeholder,
+    subType,
+    keyLabel,
+    minLength,
+    multiple,
+    allowNew,
+    onChange,
+    fieldKey,
+    keyValue,
+    editable,
+    setIsEditing,
+    clearButton,
+    question,
+  } = props;
+  useEffect(() => {
+    setFormValue(value);
+  }, [value]);
+  const getOptionValue = (option) => {
+    if (
+      allowNew &&
+      Object.prototype.hasOwnProperty.call(option, "customOption")
+    ) {
+      return option.Name;
+    }
+    if (typeof option === "string") return option;
+    return option[keyValue];
+  };
+
+  const fieldChange = (event) => {
+    if (subType === "multiChoice" || multiple) {
+      const newValue = event.map((option) => getOptionValue(option));
+      if (editable) {
+        setFormValue(newValue);
+      } else {
+        onChange({
+          key: fieldKey,
+          value: newValue,
+        });
+      }
+    } else if (editable) {
+      setFormValue(event.length === 1 ? getOptionValue(event[0]) : "");
+    } else {
+      onChange({
+        key: fieldKey,
+        value: event.length === 1 ? getOptionValue(event[0]) : "",
+      });
+    }
+  };
+
+  const getSelected = () => {
+    const selectedValue = editable ? formValue : value;
+    if (subType === "multiChoice" || multiple) {
+      if (options.length !== 0 && subType !== "async") {
+        let selected = [];
+        if (selectedValue) {
+          selected = options.filter((option) =>
+            selectedValue.includes(getOptionValue(option))
+          );
+        }
+        return selected;
+      }
+      if (typeof selectedValue === typeof "String") {
+        if (selectedValue) {
+          return [selectedValue];
+        }
+        return [];
+      }
+      return selectedValue;
+    }
+    if (
+      subType === "async" &&
+      (selectedValue !== undefined || selectedValue !== "") &&
+      (!options || options.length === 0)
+    ) {
+      if (selectedValue) {
+        if (
+          typeof selectedValue === typeof {} ||
+          typeof selectedValue === typeof []
+        ) {
+          return selectedValue;
+        }
+        return [selectedValue];
+      }
+      return [];
+    }
+    const selected = options.find(
+      (option) => getOptionValue(option) === selectedValue
+    );
+    return selected ? [selected] : [];
+  };
+  const setEditingValue = () => {
+    setIsEditing(false);
+    onChange({
+      key: fieldKey,
+      value: formValue,
+    });
+  };
+
+  const getlabel = () => {
+    if (question) {
+      return <div className="label"> {label}</div>;
+    }
+    return <Label htmlFor={id}>{label}</Label>;
+  };
+  const Component = subType === "async" ? AsyncTypeahead : Typeahead;
+  return (
+    <FormField className="form-group">
+      {label ? getlabel() : ""}
+      <SelectPanel editable={editable}>
+        <Component
+          id={id}
+          minLength={minLength}
+          onSearch={typeAheadData.fun}
+          isLoading={typeAheadData.loader}
+          options={options}
+          labelKey={keyLabel || "label"}
+          valueKey={getOptionValue}
+          selected={getSelected()}
+          onChange={fieldChange}
+          placeholder={placeholder}
+          multiple={subType === "multiChoice" || multiple}
+          useCache={false}
+          allowNew={allowNew}
+          clearButton={clearButton}
+        />
+      </SelectPanel>
+      {editable ? (
+        <div
+          style={{ position: "absolute", top: "35px", right: "20px" }}
+          className="pull-right"
+        >
+          <i
+            onClick={setEditingValue}
+            className="fa fa-check-circle fa-2x mr-2"
+            aria-hidden="true"
+          />
+          <i
+            onClick={() => setIsEditing(false)}
+            className="fa fa-times-circle fa-2x"
+            aria-hidden="true"
+          />
+        </div>
+      ) : (
+        ""
+      )}
+      <ErrorLabel>{error || ""}</ErrorLabel>
+    </FormField>
+  );
+};
+
+TypeAheadField.propTypes = {
+  setIsEditing: PropTypes.func.isRequired,
+  multiple: PropTypes.bool,
+  keyLabel: PropTypes.string,
+  options: PropTypes.arrayOf(PropTypes.any).isRequired,
+  typeAheadData: PropTypes.oneOfType([
+    PropTypes.objectOf(PropTypes.any),
+    PropTypes.func,
+  ]).isRequired,
+  id: PropTypes.string.isRequired,
+  placeholder: PropTypes.string,
+  label: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.array,
+    PropTypes.objectOf(PropTypes.any),
+    PropTypes.number,
+  ]),
+  subType: PropTypes.string,
+  onChange: PropTypes.func.isRequired,
+  error: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object,
+    PropTypes.array,
+  ]),
+  allowNew: PropTypes.bool,
+  minLength: PropTypes.number,
+  fieldKey: PropTypes.string.isRequired,
+  keyValue: PropTypes.string,
+  editable: PropTypes.bool,
+  clearButton: PropTypes.bool,
+  question: PropTypes.bool,
+};
+
+TypeAheadField.defaultProps = {
+  minLength: 0,
+  clearButton: false,
+  question: false,
+  editable: false,
+  allowNew: false,
+  error: "",
+  value: "",
+  multiple: false,
+  label: "",
+  subType: "",
+  placeholder: "",
+  keyLabel: "label",
+  keyValue: "value",
+};
+const Label = styled.label`
+  z-index: 1;
+`;
+const SelectPanel = styled.div`
+  width: ${(props) => (props.editable ? "calc(100% - 65px)" : "100%")};
+  .rbt-token {
+    background-color: #f7f7f7;
+  }
+  .rbt-menu {
+    min-width: 100%;
+    width: auto !important;
+  }
+`;
+export default TypeAheadField;


### PR DESCRIPTION
Added typeahead functionality for the package,
Typeahead can be used as an alternative to multi-select as follows:

Inside constant - 
{
    type: 'typeahead',
    subType: 'multiChoice',
    // reset of the values
    options: // specify the option
  },

For using it to call api call on typing you can use as follows - 

1. Inside constant - 

{
    type: 'typeahead',
    subType: 'async',
   // rest value
    keyLabel: // key from the api response whose value is to displayed in dropdown,
    keyValue: // key from the api response whose value is to used as value in dropdown,,
    allowNew: true, // if we want to insert any new value which is not present in response
  },

Then while rendering you can pass parameter as follows:
After passing props for assinging option field - 

{
        key_used_in_constant_file: {
          fun: // handler function to get input text and call api call accordingly,
          loader: // loader flag value to be toogle on api response,
        },
  }